### PR TITLE
Fix build break on Mac OS X

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -35,6 +35,7 @@ static void sighandler(int sig)
 	if (sig == SIGWINCH) got_winch = 1;
 	else got_signal = 1;
 #else
+	(void)sig;
 	got_signal = 1;
 #endif
 }


### PR DESCRIPTION
Since the build options are strict, we need to explicitly "use" the
unused `sig` parameter for `sighandler` when not building with
`SIGWINCH` enabled.

A quick search on the web shows that some defines control the inclusion of `SIGWINCH` on newer Mac OS versions, that might be a better approach. 